### PR TITLE
added macro `@bcomp` to support multiple expression benchmarking added in chairmarks v1.3 

### DIFF
--- a/src/PrettyChairmarks.jl
+++ b/src/PrettyChairmarks.jl
@@ -4,7 +4,7 @@ using Chairmarks
 using Printf
 import Statistics
 
-export @b, @be, @bs
+export @b, @be, @bs, @bcomp
 
 prettypercent(p) = string(@sprintf("%.2f", p * 100), "%")
 
@@ -88,6 +88,13 @@ end
 macro bs(args...)
     call = Chairmarks.process_args(args)
     :(PrettyBenchmark($call))
+end
+
+macro bcomp(expr...)
+    call = Chairmarks.process_args(expr)
+    quote
+        tuple([PrettyChairmarks.PrettyBenchmark(bnc) for bnc in $call]...)
+    end
 end
 
 _summary(io, t, args...) = withtypename(() -> print(io, args...), io, t)
@@ -302,5 +309,7 @@ function Base.show(io::IO, ::MIME"text/plain", t1::PrettyBenchmark)
     printstyled(io, allocsstr; color=:yellow)
     return print(io, ".")
 end
+
+Base.show(io::IO, m::MIME"text/plain", bmks::Tuple{Vararg{PrettyBenchmark}}) = for b in bmks Base.show(io, m, b) end
 
 end


### PR DESCRIPTION
`Chairmarks` now supports comparative benchmarks. This PR adds a new macro `@bcomp` to leverage that and print a histogram.



Example: 
Silly example, but demonstrates the point 
```julia-repl
julia> @bcomp rand(500:1000) rand(_), rand(_^2)
Chairmarks.Benchmark: 336 samples with 1 evaluation.
 Range (min … max):  333.000 ns …   3.750 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     583.000 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   607.896 ns ± 264.546 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                              
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▅
  333 ns        Histogram: log(frequency) by time       2.44 ms <

 Memory estimate: 4.06 KiB, allocs estimate: 3.
Chairmarks.Benchmark: 336 samples with 1 evaluation.
 Range (min … max):  127.459 μs …   2.437 ms  ┊ GC (min … max): 0.00% … 82.74%
 Time  (median):     442.792 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   495.488 μs ± 283.638 μs  ┊ GC (mean ± σ):  6.80% ± 16.97%

      ▃█▆▅▃▁▃▂▁▁▅ ▄▁                                             
  ▁▁▁████████████▅██▅▇▅▅▄▃▃▃▄▃▁▃▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  333 ns           Histogram: frequency by time         2.44 ms <

 Memory estimate: 1.92 MiB, allocs estimate: 3.
```