### PR TITLE
added multiple expression support for `@bs` macro, removed `@bcomp`. added common histogram axis. Fixes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This package extends
 macro `@bs` that shows statistical results of the execution, much like the
 `@benchmark` macro from
 [BenchmarkTools](https://github.com/JuliaCI/BenchmarkTools.jl).
+The macro `@bs` supports benchmarking single as well as multiple expressions (see examples below).
 
 In fact, the code is just an adaptation of the BenchmarkTools code.
 
@@ -14,6 +15,8 @@ Note that this package re-export the `@b` and `@be` macros of Chairmarks:
 therefore, there is no need to load also Chairmarks.
 
 ## Example
+
+### Benchmarking a single expression
 
 ```julia-repl
 julia> using PrettyChairmarks
@@ -29,4 +32,32 @@ Chairmarks.Benchmark: 101378 samples with 356 evaluations.
   55.7 ns         Histogram: frequency by time         189 ns <
 
  Memory estimate: 144.0 bytes, allocs estimate: 1.
+ ```
+
+### Comparing multiple expressions
+
+```julia-repl
+julia> using PrettyChairmarks
+
+julia> bb = @bs 500 rand(_), rand(_^2)
+Chairmarks.Benchmark: 888 samples with 1 evaluation.
+ Range (min … max):  291.000 ns …  1.041 μs  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     375.000 ns              ┊ GC (median):    0.00%
+ Time  (mean ± σ):   409.350 ns ± 99.203 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+  █                                                             
+  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
+  291 ns          Histogram: frequency by time         1.14 ms <
+
+ Memory estimate: 4.06 KiB, allocs estimate: 3.
+Chairmarks.Benchmark: 888 samples with 1 evaluation.
+ Range (min … max):  124.625 μs …   1.139 ms  ┊ GC (min … max): 0.00% … 88.21%
+ Time  (median):     178.646 μs               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   204.882 μs ± 107.588 μs  ┊ GC (mean ± σ):  4.37% ± 16.51%
+
+        ▅  █▆▄▁                                                  
+  ▁▁▁▁▁▁█▇▅████▇▄▁▁▁▁▁▅▁▅▅▅▆▆▆▇▅▅▅▅▄▆▅▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▇
+  291 ns        Histogram: log(frequency) by time       1.14 ms <
+
+ Memory estimate: 1.91 MiB, allocs estimate: 3.
  ```

--- a/src/PrettyChairmarks.jl
+++ b/src/PrettyChairmarks.jl
@@ -312,8 +312,9 @@ end
 
 function Base.show(io::IO, m::MIME"text/plain", bmks::Tuple{Vararg{PrettyBenchmark}})
     # set the min and max for the hist
+    histquantile = 0.99
     _hmin = minimum(t -> minimum(s -> s.time, t.b.samples), bmks)
-    _hmax = maximum(t -> maximum(s -> s.time, t.b.samples), bmks)
+    _hmax = maximum(t -> maximum(sort([s.time for s in t.b.samples])[1:round(Int, histquantile * end)]), bmks)
 
     for b in bmks 
         show(io, m, b; histmax = _hmax, histmin = _hmin)

--- a/src/PrettyChairmarks.jl
+++ b/src/PrettyChairmarks.jl
@@ -85,16 +85,12 @@ struct PrettyBenchmark
     b::Chairmarks.Benchmark
 end
 
+postprocess(b::Chairmarks.Benchmark) = PrettyBenchmark(b)
+postprocess(bmarks::Tuple{Vararg{Chairmarks.Benchmark}}) = PrettyBenchmark.(bmarks)
+
 macro bs(args...)
     call = Chairmarks.process_args(args)
-    :(PrettyBenchmark($call))
-end
-
-macro bcomp(expr...)
-    call = Chairmarks.process_args(expr)
-    quote
-        tuple([PrettyChairmarks.PrettyBenchmark(bnc) for bnc in $call]...)
-    end
+    :(postprocess($call))
 end
 
 _summary(io, t, args...) = withtypename(() -> print(io, args...), io, t)

--- a/src/PrettyChairmarks.jl
+++ b/src/PrettyChairmarks.jl
@@ -95,7 +95,7 @@ end
 
 _summary(io, t, args...) = withtypename(() -> print(io, args...), io, t)
 
-Base.summary(io::IO, t::PrettyBenchmark) = _summary(io, t, prettytime(minimum(t -> t.time, bb.b.samples)))
+Base.summary(io::IO, t::PrettyBenchmark) = _summary(io, t, prettytime(minimum(t -> t.time, t.b.samples)))
 
 _show(io, t) =
     if get(io, :compact, true)
@@ -316,7 +316,7 @@ function Base.show(io::IO, m::MIME"text/plain", bmks::Tuple{Vararg{PrettyBenchma
     _hmax = maximum(t -> maximum(s -> s.time, t.b.samples), bmks)
 
     for b in bmks 
-        Base.show(io, m, b; histmin = _hmin, histmax = _hmax)
+        Base.show(io, m, b; histmax = _hmax, histmin = _hmin)
         print(io, "\n")
     end
 end

--- a/src/PrettyChairmarks.jl
+++ b/src/PrettyChairmarks.jl
@@ -110,7 +110,7 @@ _show(io, t) =
 
 Base.show(io::IO, t::PrettyBenchmark) = _show(io, t)
 
-function Base.show(io::IO, ::MIME"text/plain", t1::PrettyBenchmark)
+function Base.show(io::IO, ::MIME"text/plain", t1::PrettyBenchmark; histmax::Union{T,Nothing} = nothing, histmin::Union{T,Nothing} = nothing) where {T<:AbstractFloat}
     t = t1.b
     pad = get(io, :pad, "")
     print(
@@ -229,8 +229,12 @@ function Base.show(io::IO, ::MIME"text/plain", t1::PrettyBenchmark)
     histwidth = 42 + lmaxtimewidth + rmaxtimewidth
 
     histtimes = times[1:round(Int, histquantile * end)]
-    histmin = get(io, :histmin, first(histtimes))
-    histmax = get(io, :histmax, last(histtimes))
+    if histmin === nothing 
+        histmin = get(io, :histmin, first(histtimes))
+    end
+    if histmax === nothing
+        histmax = get(io, :histmax, last(histtimes))
+    end
     logbins = get(io, :logbins, nothing)
     bins = bindata(histtimes, histwidth - 1, histmin, histmax)
     append!(bins, [1, floor((1 - histquantile) * length(times))])
@@ -310,6 +314,15 @@ function Base.show(io::IO, ::MIME"text/plain", t1::PrettyBenchmark)
     return print(io, ".")
 end
 
-Base.show(io::IO, m::MIME"text/plain", bmks::Tuple{Vararg{PrettyBenchmark}}) = for b in bmks Base.show(io, m, b) end
+function Base.show(io::IO, m::MIME"text/plain", bmks::Tuple{Vararg{PrettyBenchmark}})
+    # set the min and max for the hist
+    _hmin = minimum(t -> minimum(s -> s.time, t.b.samples), bmks)
+    _hmax = maximum(t -> maximum(s -> s.time, t.b.samples), bmks)
+
+    for b in bmks 
+        Base.show(io, m, b; histmin = _hmin, histmax = _hmax)
+        print(io, "\n")
+    end
+end
 
 end

--- a/src/PrettyChairmarks.jl
+++ b/src/PrettyChairmarks.jl
@@ -316,7 +316,7 @@ function Base.show(io::IO, m::MIME"text/plain", bmks::Tuple{Vararg{PrettyBenchma
     _hmax = maximum(t -> maximum(s -> s.time, t.b.samples), bmks)
 
     for b in bmks 
-        Base.show(io, m, b; histmax = _hmax, histmin = _hmin)
+        show(io, m, b; histmax = _hmax, histmin = _hmin)
         print(io, "\n")
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ using Test
     @test startswith(s, r"Chairmarks\.Benchmark: [0-9]* samples? with [0-9]* evaluations?\.")
     @test endswith(s, "allocs estimate: 0.")
     @test occursin(r"Histogram: (log\()?frequency\)? by time", s)
+    bb = @bs sleep(0.001), sleep(0.01); @test (bb isa Tuple)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,5 @@ using Test
     @test endswith(s, "allocs estimate: 0.")
     @test occursin(r"Histogram: (log\()?frequency\)? by time", s)
     bb = @bs sleep(0.001), sleep(0.01); @test (bb isa Tuple)
+    b1 = @bs sleep(0.001); @test !(b1 isa Tuple)
 end


### PR DESCRIPTION
This PR modifies the `Base.show` method for comparative benchmarking using `@bcomp` to display histograms with a common x-axis, making them histograms directly comparable. Also fixes #8

```julia-repl
julia> @bs rand(500:1000) rand(_), rand(_^2)
Chairmarks.Benchmark: 336 samples with 1 evaluation.
 Range (min … max):  333.000 ns …   3.750 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     583.000 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   607.896 ns ± 264.546 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █                                                              
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▅
  333 ns        Histogram: log(frequency) by time       2.44 ms <

 Memory estimate: 4.06 KiB, allocs estimate: 3.
Chairmarks.Benchmark: 336 samples with 1 evaluation.
 Range (min … max):  127.459 μs …   2.437 ms  ┊ GC (min … max): 0.00% … 82.74%
 Time  (median):     442.792 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   495.488 μs ± 283.638 μs  ┊ GC (mean ± σ):  6.80% ± 16.97%

      ▃█▆▅▃▁▃▂▁▁▅ ▄▁                                             
  ▁▁▁████████████▅██▅▇▅▅▄▃▃▃▄▃▁▃▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  333 ns           Histogram: frequency by time         2.44 ms <

 Memory estimate: 1.92 MiB, allocs estimate: 3.
```